### PR TITLE
fix: resolving the bug in Donations related to the request function

### DIFF
--- a/src/services/donations.js
+++ b/src/services/donations.js
@@ -40,7 +40,6 @@ export async function getCampaignDonations(campaign) {
   return new Promise((resolve, reject) => {
     getRaiselyToken().then(token => {
       request(url, { headers: { Authorization: `Bearer ${token}` } })
-        .then(response => response.json())
         .then(response => resolve(response.data))
         .catch(error => reject(error));
     });
@@ -54,15 +53,17 @@ export async function getRaiselyToken() {
     if (raiselyToken) {
       resolve(raiselyToken);
     } else {
-      request(`${API}/login`, {
-        method: 'POST',
-        body: JSON.stringify(LOGIN_ACCESS),
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json; charset=utf-8',
+      request(
+        `${API}/login`, 
+        {
+          method: 'POST',
+          body: LOGIN_ACCESS,
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json; charset=utf-8',
+          },
         },
-      })
-        .then(response => response.json())
+      )
         .then(jsonData => {
           const { token } = jsonData;
           setOnStorage('raisely_token', token);


### PR DESCRIPTION
We were using `fetch` in the old architecture, that's why it was failing because we were using our own function `request` with `cross-fetch`. I made the changes to make it work