### PR TITLE
Hotfix - CTA's clickable on mobile

### DIFF
--- a/components/ctaGrid/ctaGrid.module.scss
+++ b/components/ctaGrid/ctaGrid.module.scss
@@ -59,10 +59,6 @@
       .subItemDetails {
         display: block;
       }
-
-      .itemContentImage {
-        display: none;
-      }
     }
 
     .ctaGridBtn {


### PR DESCRIPTION
Display the img on CTA's hover on mobile version

- Deleted the display:none of the .itemContentImage ::hover 