### PR TITLE
Added polyfills to fix bugsnag errors

### DIFF
--- a/client/polyfills.js
+++ b/client/polyfills.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint no-extend-native: 0 */
+// core-js comes with Next.js. So, you can import it like below
+import includes from 'core-js/library/fn/string/virtual/includes';
+import repeat from 'core-js/library/fn/string/virtual/repeat';
+import assign from 'core-js/library/fn/object/assign';
+
+// Add your polyfills
+// This files runs at the very beginning (even before React and Next.js core)
+// eslint-disable-next-line no-console
+console.log('Load your polyfills');
+
+String.prototype.includes = includes;
+String.prototype.repeat = repeat;
+Object.assign = assign;

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,19 @@ const withOffline = require('next-offline');
 module.exports = withOffline(
   withCSS(
     withSass({
-      webpack(config) {
+      webpack: (config) => {
+        const originalEntry = config.entry;
+        // eslint-disable-next-line no-param-reassign
+        config.entry = async () => {
+          const entries = await originalEntry();
+          if (
+            entries['main.js']
+              && !entries['main.js'].includes('./client/polyfills.js')
+          ) {
+            entries['main.js'].unshift('./client/polyfills.js');
+          }
+          return entries;
+        };
         return config;
       },
       exportTrailingSlash: false,


### PR DESCRIPTION
resolves #98

There are some `bugsnag` errors for `IE11` 
For example: `Object doesn't support property or method 'assign'`
I added some polyfills to the nextjs.config to fix this.
I couldn't test on a windows computer so;

- I opened safari
- Preferences
- Advanced
- checked the box that says `Show Develop menu in the menu bar`
- develop
- user agent -> selected Microsoft Edge

If all is good you should see a console log saying `Load your polyfills`