### PR TITLE
Be a mentor - App open txt

### DIFF
--- a/components/beAMentor/beAMentorForm.js
+++ b/components/beAMentor/beAMentorForm.js
@@ -14,16 +14,15 @@ const BeAMentorForm = () => (
     />
     <Title type="h5Title">Mentor applications are now open!</Title>
     <Paragraph>
-      <br />
-      <mark>Excited? We are too! </mark>
-      <br />
-      <br />
-      Mentors applications are up and running.
-      <br />
-      <br />
-      If you are new to mentoring with us, create an AIME account and we`&apos;`ll
-      guide through the application process. If you are a returning mentor,
-      welcome back. Sign in to your account to finalise your application for
+      Excited? We are too!&nbsp;
+      <mark>
+        Mentors applications are up and running.
+      </mark>
+    </Paragraph>
+    <Paragraph>
+      If you are new to mentoring with us, create an AIME account and we'll
+      guide through your application process. If you are a returning mentor,
+      welcome back. Sign in to your account below and finalise your application for
       this year.
     </Paragraph>
     <Button

--- a/components/beAMentor/beAMentorForm.module.scss
+++ b/components/beAMentor/beAMentorForm.module.scss
@@ -6,6 +6,10 @@
   margin: 0 auto;
   padding: 2em 3em;
 
+  h5 {
+    margin-bottom: 1em;
+  }
+
   img{
     width: 211px;
     margin-bottom: 1.5em;


### PR DESCRIPTION
I edited the text to inform that applications are open.
- change the title for an h5Title type component **(I have an issue with blueprint that's why I am not getting styles from h4/h5 titles, you should be able to see it just fine in your computer)**
- also added one class for the img because it used to have inline styling
- Feel free to tell me about any text adjustments if needed!
- Change the button terxt from **Sing up** to **Apply now**

Maybe I should change the <mark> to Mentors applications are up and running! or just delete it...

<img width="614" alt="Captura de Pantalla 2020-03-06 a la(s) 12 36 54" src="https://user-images.githubusercontent.com/29383328/76041852-6496c100-5fa7-11ea-93a0-f8678b519f23.png">
