### PR TITLE
fix: adds stage default value in staff recruitment

### DIFF
--- a/pages/positions/[positionId]/[jobCategory].js
+++ b/pages/positions/[positionId]/[jobCategory].js
@@ -149,6 +149,7 @@ const PositionsEntry = () => {
         job_name: state.job.name,
         job_location: state.job.city,
         submissionmessage: 'jobs',
+        stage: 'Initial Review',
       },
     });
     if (answer.data === 'OK') {


### PR DESCRIPTION
Adds stage value to staff recruitment, we needed for positions page in the website.

Related to the bug Kristy mentioned in an email @camposcristianeze @lubem234 

https://github.com/aimementoring/aime-portal-api/pull/183