### PR TITLE
Fix: Fix typo and link to non-existing page.

### DIFF
--- a/components/jobs/index.js
+++ b/components/jobs/index.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropType from 'prop-types';
 import dynamic from 'next/dynamic';
 import compact from 'lodash/compact';
-import Anchor from '../common/link';
 import { loadPositions } from '../../services/positions';
 import { formatJobs } from '../../utils/positions';
 import { COUNTRIES_WHERE_AIME_ACCEPT_JOBS } from '../../constants';
@@ -222,9 +221,9 @@ const Jobs = ({
           <h1 className="lh-base">We are not hiring.</h1>
           <span className="line bg-brand-tertiary mb3 mt1" />
           <p className="pb1 md-pb3 lg-pb3">
-            Sorry, there are no positions available at the moment. You can
-            <Anchor to="/be-a-friend" as="/be-a-friend">sign up to be an AIME Friend</Anchor>
-            {'though and receive updates about everything that\'s happening.'}
+            {`Sorry, there are no positions available at the moment. 
+            You can sign up to be an AIME Friend at the bottom of this page though, 
+            and receive updates about everything that's happening.`}
           </p>
         </div>
       )}


### PR DESCRIPTION
<img width="743" alt="Screenshot 2020-03-18 at 18 36 18" src="https://user-images.githubusercontent.com/294558/76993813-be0ad280-694d-11ea-8b10-4bbfc8db841a.png">
This is what the positions page on the website looks like right now, and the link leads to a page that doesn't exist anymore. 🙈 