### PR TITLE
Feature: Display intercom on /contact

### DIFF
--- a/hocs/basicLayout.js
+++ b/hocs/basicLayout.js
@@ -5,9 +5,23 @@ import ErrorBoundary from '../components/common/errorBoundary';
 import Header from '../components/layoutComponents/header';
 import Footer from '../components/layoutComponents/footer';
 import Logos from '../components/layoutComponents/logos';
+import isClientSide from '../utils/isClientSide';
 import './basicLayout.scss';
 
 const Layout = ({ router, children }) => {
+  const openIntercomIfContactPath = () => {
+    const { asPath } = router;
+    if (asPath && asPath === '/contact') {
+      if (isClientSide() && window && window.Intercom) {
+        window.Intercom('showNewMessage');
+      }
+    }
+  };
+
+  useEffect(() => {
+    openIntercomIfContactPath();
+  }, [router]);
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [router.pathname]);

--- a/server.js
+++ b/server.js
@@ -55,6 +55,10 @@ app.prepare().then(() => {
       });
     }
 
+    server.get('/contact', (req, res) => {
+      ssrCache({ req, res, pagePath: '/' });
+    });
+
     server.get('*', (req, res) => {
       if (req.path.substr(-1) === '/' && req.path.length > 1) {
         const query = req.url.slice(req.path.length);


### PR DESCRIPTION
Hey crew!

Not sure if a) this is a good idea and if b) even if it is, if it is the best way to implement this.

**Background**: People are still coming to the /contact page, although we haven't linked it anywhere anymore. I also noticed that it is weird to not be able to link to a contact form from emails or places outside of our own websites.

**Idea**: '/contact' could still work and just display the home page with an open intercom. (Needs to be tested how well this works on different devices.)

