### PR TITLE
Adding word break to card para

### DIFF
--- a/components/card/card.module.scss
+++ b/components/card/card.module.scss
@@ -55,6 +55,10 @@
     height: calc(100% - 10.5em);
     position: relative;
 
+    p {
+      word-break: break-all;
+    }
+
     &.withVideo {
       height: calc(100% - 21.75em);
     }


### PR DESCRIPTION
@mischacolley pointed out that the text was overflowing the card component on Stories: https://www.dropbox.com/s/f14ua9yvrihuljt/Screenshot%202020-04-06%2009.15.55.png?dl=0

I've added a word break style to this excerpt para but I do think there might be an issue with contentful... Maybe, @bronz3beard? Because I thought this was a problem of the content writer adding in plain-text links rather than hyperlinking the words. Though when you go [into the story](https://www.aimementoring.com/story/intv-changing-the-way-kids-learn-a-conversation-with-nancy-conrad-and-jack-manning-bancroft), the links are all hyperlinked properly... 