### PR TITLE
fixing flex-basis rule

### DIFF
--- a/components/heroBannerHomepage/heroBannerHomepage.module.scss
+++ b/components/heroBannerHomepage/heroBannerHomepage.module.scss
@@ -78,8 +78,7 @@
   .bannerItem {
     box-sizing: border-box;
     flex-grow: 1;
-    // @TODO: Review why it is failing on iOS device, it should be flex-basis: 0;
-    flex-basis: 1;
+    flex-basis: auto;
     clear: both;
     display: flex;
     flex-direction: column;

--- a/pages/imagi-nation-tv/imagi-nation-tv.module.scss
+++ b/pages/imagi-nation-tv/imagi-nation-tv.module.scss
@@ -40,7 +40,7 @@
     .bannerItem {
       box-sizing: border-box;
       flex-grow: 1;
-      flex-basis: 0;
+      flex-basis: auto;
       clear: both;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
hey @kbardi @camposcristianeze - this small fix should resolve the broken layout on the home & intv banners. @kbardi  you were close with `flex-basis:1;` but unfortunately `1` is not a valid entry - it needs to be a fraction of 1 or `auto`. You can read up on it more [here](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) if you like :)  Also, you had only changed it on the home page but there was an issue on the intv page too. 