### PR TITLE
(not so) small banner responsive fix

### DIFF
--- a/components/heroBannerHomepage/heroBannerHomepage.module.scss
+++ b/components/heroBannerHomepage/heroBannerHomepage.module.scss
@@ -3,7 +3,7 @@
 .heroBannerHomepage {
   background:
     url($cdnRoot+"assets/images/decorative/dotties@2x.jpg") no-repeat 100% 100% transparent;
-  background-size: 100% 40%;
+  background-size: 100%;
   position: relative;
   max-width: 75em;
   width: 100%;
@@ -11,13 +11,16 @@
   margin: 6em auto 0;
 
   @media screen and (min-width: $sm) {
-    background-size: 80% 65%;
+    background-size: 75%;
   }
 
   @media screen and (min-width: $md) {
     background-position: 90% 80%;
-   
-    background-size: 60% 90%;
+    background-size: 70%;
+  }
+
+  @media screen and (min-width: $lg) {
+    background-size: 50%;
   }
   
   .welcomeTitle {
@@ -69,7 +72,7 @@
       display: flex;
     }
 
-    @media screen and (min-width: $md) {
+    @media screen and (min-width: $lg) {
       flex-direction: row;
       align-items: center;
       padding: 2em;
@@ -120,10 +123,13 @@
       }
 
       @media screen and (min-width: $md) {
-        align-self: center;
         flex-grow: 1.33;
+        margin-top: -5em;
+        min-width: 35em;
+      }
+      @media screen and (min-width: $lg) {
         margin-top: 0;
-        top: 2em;
+        min-width: unset;
       }
 
       .dancingIllo {

--- a/components/quicklinksHomepage/style.scss
+++ b/components/quicklinksHomepage/style.scss
@@ -3,7 +3,7 @@
 .quicklinksPanel {
   max-width: 60em;
   margin: 0 auto;
-  padding: 5em 1em 2em;
+  padding: 2em 1em;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/pages/imagi-nation-tv/imagi-nation-tv.module.scss
+++ b/pages/imagi-nation-tv/imagi-nation-tv.module.scss
@@ -3,7 +3,7 @@
 .heroBannerImagiTV {
   background:
     url($cdnRoot+"assets/images/decorative/dotties@2x.jpg") no-repeat 100% 100% transparent;
-  background-size: 100% 40%;
+  background-size: 100%;
   position: relative;
   max-width: 75em;
   width: 100%;
@@ -11,13 +11,16 @@
   margin: 6em auto 0;
 
   @media screen and (min-width: $sm) {
-    background-size: 80% 65%;
+    background-size: 75%;
   }
 
   @media screen and (min-width: $md) {
     background-position: 90% 80%;
-   
-    background-size: 60% 90%;
+    background-size: auto 68%;
+  }
+
+  @media screen and (min-width: $lg) {
+    background-size: auto 90%;
   }
 
   .bannerWrapper {
@@ -31,7 +34,7 @@
       display: flex;
     }
   
-    @media screen and (min-width: $md) {
+    @media screen and (min-width: $lg) {
       flex-direction: row;
       align-items: center;
       padding: 2em;
@@ -73,14 +76,14 @@
       align-self: flex-end;
       text-align: right;
       font-family: $body-font-family;
-      min-width: 28em;
+      min-width: 100%;
   
       @media screen and (min-width: $sm) {
         margin-top: 0;
+        min-width: 28em;
       }
   
       @media screen and (min-width: $md) {
-        align-self: center;
         flex-grow: 2;
       }
 


### PR DESCRIPTION
On staging.aimementoring.com the banners on the `/home` and `imagi-nation-tv` pages look off in diff responsive sizes - 

<img width="1680" alt="Screen Shot 2020-05-01 at 3 32 31 pm" src="https://user-images.githubusercontent.com/39749772/80784707-5210c080-8bc1-11ea-939a-a82b627cae76.png">

I made small css changes locally to get them to respond appropriately which look great in my localhost but each time they're deployed, they behave in a diff way. 

My local version: 
<img width="1680" alt="Screen Shot 2020-05-01 at 3 32 41 pm" src="https://user-images.githubusercontent.com/39749772/80784757-6e146200-8bc1-11ea-99d8-94c0d38ee0ab.png">

The deployed version of this PR:
<img width="1680" alt="Screen Shot 2020-05-01 at 3 33 17 pm" src="https://user-images.githubusercontent.com/39749772/80784768-77053380-8bc1-11ea-8ac6-b8f601bdcb9f.png">


Watch my loom I've left below 👇 I think it has something to do with CSS modules migration because there seems to be extra classes applied when looking at the deployed version compared to the local version. **Reminder: the issue is on both the homepage banner and the intv banner**. 