### PR TITLE
Fix: Don't show arrows on story header carousel.

### DIFF
--- a/components/storiesComponents/storiesCarousel/index.js
+++ b/components/storiesComponents/storiesCarousel/index.js
@@ -8,8 +8,8 @@ import styles from './storiesCarousel.module.scss';
 
 const StoriesCarousel = ({ entries }) => (
   <div className={styles.carouselContainer}>
-    <div className={styles.carousel}>
-      <Carousel>
+    <div className={styles.storyCarousel}>
+      <Carousel carouselClassName={styles.storyHeaderCarousel}>
         {entries.map(({
           fields: {
             banner, title, slug, contentPreview, contentCards,

--- a/components/storiesComponents/storiesCarousel/storiesCarousel.module.scss
+++ b/components/storiesComponents/storiesCarousel/storiesCarousel.module.scss
@@ -4,7 +4,7 @@
   min-height: 71vh;
 }
 
-.carousel {
+.storyCarousel {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -12,6 +12,10 @@
 
   @media screen and (min-width: $md) {
     margin-bottom: 4rem;
+  }
+
+  .storyHeaderCarousel :global(.slick-arrow) {
+    display: none !important;
   }
 
   :global(.slick-slider) {
@@ -129,20 +133,6 @@
         display: block;
       }
     }
-
-    .productTitle {
-      color: $white;
-      font-family: $primary-font-family;
-      font-size: 0.8rem;
-      line-height: 1.5;
-      font-weight: 400;
-      margin-top: 0.5rem;
-    }
   }
 }
-
-.carouselLink {
-  color: $white;
-  font-weight: 700;
-} 
 


### PR DESCRIPTION
Side effect of our CSS modules stuff … carousel arrows are appearing on the story banner. 😬 

![IMG_8593](https://user-images.githubusercontent.com/294558/81673477-ff9a9400-944b-11ea-8b24-ea1079072235.png)
