### PR TITLE
Fix: Fix jumpy weekday carousel.

### DIFF
--- a/components/imaginationTv/imaginationTvCarousel.module.scss
+++ b/components/imaginationTv/imaginationTvCarousel.module.scss
@@ -31,6 +31,7 @@
 
     .slick-slide .episodePanel .episodeContentInfo {
       display: none;
+
     }
     
     .slick-center .episodePanel .episodeContentInfo {
@@ -41,4 +42,5 @@
 
 .episodePanel {
   opacity: 50%;
+  min-height: 60em;
 }


### PR DESCRIPTION
This is more a discussion starter than a PR to merge. I think it SHOULD NOT BE MERGED.

Problems:
- You cannot use the arrows to quickly click through the carousels (especially not the weekday carousel), because they will jump around, because they are centered in a container whose size changes.
- If you are viewing content below a carousel, but the carousel still is in your view port, then the content will jump around.

I think the idea of the carousel is that the items/cards/slides have ALL THE SAME height, like in a deck of cards or in a slide show. I know that's not how we're using it.

My suggestion:
- Make slides same-height for ALL carousels.
- Shorten text for Tuesday. Maybe add some more text for Monday.

https://www.loom.com/share/014c225fd77f4381a7eac7c7717b60fe
