### PR TITLE
Banner style fix for pages with low menu contrast

### DIFF
--- a/components/banner/banner.module.scss
+++ b/components/banner/banner.module.scss
@@ -4,13 +4,17 @@
   align-items: center;
   background-position: 0% 25%;
   display: flex;
-  height: 71vh;
+  min-height: 18em;
   justify-content: flex-start;
   position: relative;
-  width: 100%;
+  margin: 7.5em auto 0;
+  @media screen and (min-width: $md) {
+    width: 96%;
+    min-height: 33em;
+  }
 
   &:before {
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: $purple + ba;
     bottom: 0;
     content: "";
     display: block;
@@ -21,15 +25,11 @@
   }
 
   .featuredStory {
-    color: $white;
-    width: 1330px;
-    margin-left: auto;
-    max-width: 1330px;
-    margin-right: auto;
-    padding-left: 2rem;
     position: relative;
-    padding-top: 8rem;
-    padding-right: 2rem;
+    color: $white;
+    max-width: 33em;
+    margin: 0 auto;
+    padding: 0 2em;
     text-align: center;
     
     .textWrap {
@@ -38,11 +38,12 @@
     }
 
     h3 {
-      font-size: 2rem;
+      font-size: 1.5rem;
       margin-bottom: 1.2em;
 
       @media screen and (min-width: $md) {
       margin: 0.7em 0;
+      font-size: 2rem;
       }
     }
 

--- a/components/heroBannerAbout/heroBannerAbout.module.scss
+++ b/components/heroBannerAbout/heroBannerAbout.module.scss
@@ -20,12 +20,12 @@
     background-position: bottom;
     background-size: cover;
     display: flex;
-    height: 70vh;
+    height: 55vh;
     justify-content: center;
     position: relative;
     width: 100%;
     padding: 0;
-    margin:1em 1em 0em 1em;
+    margin: 7.5em 1em 0em 1em;
 
     @media screen and (max-device-width: 1024px) {
       background-attachment: scroll;
@@ -40,7 +40,6 @@
       color: $white;
       text-align: center;
       line-height: 1em;
-      margin-top: 2em;
 
       strong {
         top: inherit;

--- a/components/storiesComponents/storiesCarousel/storiesCarousel.module.scss
+++ b/components/storiesComponents/storiesCarousel/storiesCarousel.module.scss
@@ -1,7 +1,9 @@
 @import "../../../styles/global.module.scss";
 
 .carouselContainer {
-  min-height: 71vh;
+  max-width: 81.25em;
+  max-height: 50em;
+  margin: 0 auto;
 }
 
 .storyCarousel {
@@ -9,10 +11,6 @@
   flex-direction: column;
   justify-content: center;
   margin-bottom: 2rem;
-
-  @media screen and (min-width: $md) {
-    margin-bottom: 4rem;
-  }
 
   .storyHeaderCarousel :global(.slick-arrow) {
     display: none !important;

--- a/components/storiesComponents/storyCategorySelector/storyCategorySelector.module.scss
+++ b/components/storiesComponents/storyCategorySelector/storyCategorySelector.module.scss
@@ -11,7 +11,11 @@
       border: 1px solid $watermelon;
       box-sizing: border-box;
       border-radius: 3px;
-      margin: 0 2em 2em 0;
+      margin: 0 1em 1em 0;
+      
+      @media screen and (min-width: $md) {
+        margin: 0 1em 2em 0;
+      }
 
       &.allTab {
         min-width: 8em;

--- a/pages/know-aime/index.js
+++ b/pages/know-aime/index.js
@@ -48,8 +48,8 @@ const KnowAime = () => (
             </div>
           </div>
         </div>
+        <MovingWaves />
       </div>
-      <MovingWaves />
       <div className={styles.grid}>
         <div className={styles.sidebar}>
           <div>

--- a/pages/know-aime/know-aime.module.scss
+++ b/pages/know-aime/know-aime.module.scss
@@ -30,13 +30,14 @@
   background-size: cover;
   overflow: hidden;
   position: relative;
-  width: 100%;
+  width: 96%;
+  margin: 7.5em auto 0;
   display: flex;
   align-items: center;
   justify-content: center;
 
   @media screen and (min-width: $sm) {
-    height: 100vh;
+    height: 65vh;
   }
 }
 

--- a/pages/story/[slug].js
+++ b/pages/story/[slug].js
@@ -54,7 +54,7 @@ const Story = ({ content }) => {
             <div>
               <div className={styles.entriesContainer}>
                 <article className={styles.blogPost}>
-                  <Title type="h3Title" theme="rainbow">
+                  <Title type="h3Title" theme="rainbow" className={styles.blogPostTitle}>
                     {title}
                   </Title>
                   <BadgeList items={postCategories} itemClass={styles.borderedBadge} isLinked />

--- a/pages/story/story.module.scss
+++ b/pages/story/story.module.scss
@@ -6,6 +6,8 @@
   background-position: 0% 25%;
   max-width: 100%;
   height: 65vh;
+  width: 96%;
+  margin: 7.5em auto 0;
   background-size: cover;
   position: relative;
 
@@ -58,6 +60,14 @@
   @media screen and (max-width: $sm) {
     margin: 0;
     padding: 30px 0 4rem 0;
+  }
+
+  .blogPostTitle {
+    font-size: 2rem;
+
+    @media screen and (min-width: $md) {
+    font-size: 2.5rem;
+    }
   }
 
   .blogPostTimestamp {


### PR DESCRIPTION
Mainly for stories - bringing the banner in away from the top edges so that the menu is contrasted well against the background. To go with the new menu - https://github.com/aimementoring/website/pull/426

Eg.

<img width="1680" alt="Screen Shot 2020-05-26 at 3 00 24 pm" src="https://user-images.githubusercontent.com/39749772/82977691-f271cd80-a025-11ea-90c1-5a34718204dc.png">
