### PR TITLE
fix: trailing space in Safari on Be a Partner in Footer links

### DIFF
--- a/components/navList/navItem.module.scss
+++ b/components/navList/navItem.module.scss
@@ -19,6 +19,7 @@
   font-family: $body-font-family;
   font-weight: 300;
   background: none;
+  margin: 0;
   border: none;
   padding: 0;
   text-decoration: underline;


### PR DESCRIPTION
Remove small margin autogenerated in Safari in **Be a Partner** link, detected and reported in this [issue](https://github.com/aimementoring/website/issues/501)